### PR TITLE
fix: ignore update messages from itself

### DIFF
--- a/watcher.go
+++ b/watcher.go
@@ -109,7 +109,7 @@ func (w *Watcher) Update() error {
 	w.lock.Lock()
 	defer w.lock.Unlock()
 	resp, err := w.client.Put(context.TODO(), w.keyName, "")
-	if err != nil {
+	if err == nil {
 		w.lastSentRev = resp.Header.GetRevision()
 	}
 	return err

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -15,10 +15,8 @@
 package etcdwatcher
 
 import (
-	"context"
 	"log"
 	"testing"
-	"time"
 
 	"github.com/casbin/casbin/v2"
 )
@@ -65,17 +63,9 @@ func TestWithEnforcer(t *testing.T) {
 	_ = w.SetUpdateCallback(updateCallback)
 
 	// Update the policy to test the effect.
-	// You should see nothing output because the etcd message is ignored by itself.
+	// You should see "[New revision detected: X]" in the log.
 	err := e.SavePolicy()
 	if err != nil {
 		t.Fail()
 	}
-
-	// Simulate the update from other instance.
-	// You should see "[New revision detected: X]" in the log.
-	_, err = w.(*Watcher).client.Put(context.TODO(), "/casbin", "")
-	if err != nil {
-		t.Fail()
-	}
-	time.Sleep(time.Millisecond * 100)
 }

--- a/watcher_test.go
+++ b/watcher_test.go
@@ -15,8 +15,10 @@
 package etcdwatcher
 
 import (
+	"context"
 	"log"
 	"testing"
+	"time"
 
 	"github.com/casbin/casbin/v2"
 )
@@ -63,9 +65,17 @@ func TestWithEnforcer(t *testing.T) {
 	_ = w.SetUpdateCallback(updateCallback)
 
 	// Update the policy to test the effect.
-	// You should see "[New revision detected: X]" in the log.
+	// You should see nothing output because the etcd message is ignored by itself.
 	err := e.SavePolicy()
 	if err != nil {
 		t.Fail()
 	}
+
+	// Simulate the update from other instance.
+	// You should see "[New revision detected: X]" in the log.
+	_, err = w.(*Watcher).client.Put(context.TODO(), "/casbin", "")
+	if err != nil {
+		t.Fail()
+	}
+	time.Sleep(time.Millisecond * 100)
 }


### PR DESCRIPTION
Fix: https://github.com/casbin/etcd-watcher/pull/22

When policy changes, etcd-watcher will `Put` a message into etcd, then the revision of key will be updated. 
```go
resp, err := w.client.Put(context.TODO(), w.keyName, "")
```
At the same time, etcd-watcher will get this new revision because it is watching this key.
```go
func (w *Watcher) startWatch() error {
	watcher := w.client.Watch(context.Background(), w.keyName)
```

So in last pr #22 , to prevent consuming the messages put by self, every time etcd-watcher put a message, it will record the revision from the `Put` response. And in the goroutine for `Watch`, it will verify the revision of received message is bigger than recorded one or not.
```go
for res := range watcher {
    t := res.Events[0]
    if t.IsCreate() || t.IsModify() {
	  w.lock.RLock()
	  //ignore self update
	  if rev := t.Kv.ModRevision; rev > w.lastSentRev && w.callback != nil {
		  w.callback(strconv.FormatInt(rev, 10))
	  }
	  w.lock.RUnlock()
    }
}
```

But in the `Update` function, it only update local recorded revision when `Put` fails, it means this feature will be never triggered.
```go
func (w *Watcher) Update() error {
	w.lock.Lock()
	defer w.lock.Unlock()
	resp, err := w.client.Put(context.TODO(), w.keyName, "")
        // We should update lastSentRev when put operation succeeds, but not when it fails.
        // if err != nil {
	if err == nil {
		w.lastSentRev = resp.Header.GetRevision()
	}
	return err
}
```